### PR TITLE
Add Rodrigues et al. (2021) paper

### DIFF
--- a/entries.json
+++ b/entries.json
@@ -261,5 +261,25 @@
       "Related to Wiqvist et al. (2021) above."
     ],
     "link": "https://openreview.net/forum?id=kZ0UYdhqkNY"
+  },
+  {
+    "authors": [
+      "Pedro L. C. Rodrigues",
+      "Thomas Moreau",
+      "Gilles Louppe",
+      "Alexandre Gramfort"
+    ],
+    "title": "HNPE: Leveraging Global Parameters for Neural Posterior Estimation",
+    "date": "December, 2021",
+    "target": [
+      "posterior"
+    ],
+    "nn": "normalizing-flows",
+    "samples": "direct",
+    "sequential": "yes",
+    "other": [
+      "[Code](https://github.com/plcrodrigues/HNPE)"
+    ],
+    "link": "https://proceedings.neurips.cc/paper/2021/hash/6fbd841e2e4b2938351a4f9b68f12e6b-Abstract.html"
   }
 ]

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@ layout: default
     <span>Authors: </span>
     <select id="authorselection" class="selectpicker" multiple data-live-search="true">
 <option>Aleksandra M. Walczak</option>
+<option>Alexandre Gramfort</option>
 <option>Andreas Hellander</option>
 <option>Andreass Voss</option>
 <option>Armita Nourmohammad</option>
@@ -34,6 +35,7 @@ layout: default
 <option>Michael Deistler</option>
 <option>Natanael Spisak</option>
 <option>Pedro J. Gonçalves</option>
+<option>Pedro L. C. Rodrigues</option>
 <option>Poornima Ramesh</option>
 <option>Prashant Singh</option>
 <option>Richard Jiang</option>
@@ -45,6 +47,7 @@ layout: default
 <option>Stefan T. Radev</option>
 <option>Theofanis Karaletsos</option>
 <option>Thierry Mora</option>
+<option>Thomas Moreau</option>
 <option>Ulf K. Mertens</option>
 <option>Ullrich Köthe</option>
 <option>Umberto Picchini</option>
@@ -802,6 +805,53 @@ layout: default
 {% capture x %}
 * Considers a set of particles which will be a posterior approximation
 * The particles are fitted to the posterior by alternating between NN training and Stein Variaional Gradient Descent steps
+{% endcapture %}{{ x | markdownify }}
+</div>
+ <hr/>
+</div>
+<!--EndPost--------------------------------------------------------------------------------------------------------------------------------------------->
+        <!--Post--------------------------------------------------------------------------------------------------------------------------------------------->
+{% assign id = id | plus:1 %}
+<div class="entry">
+	<div class="row">
+	  <div class="column1" >
+{% capture x %}
+## HNPE: Leveraging Global Parameters for Neural Posterior Estimation
+    {% endcapture %}{{ x | markdownify }}
+	  </div>
+	  <div class="column2" >
+	    <div id="block_container">
+		<div id="bloc2">
+ 		<a href="https://proceedings.neurips.cc/paper/2021/hash/6fbd841e2e4b2938351a4f9b68f12e6b-Abstract.html" target="_blank" class="btn btn-info" role="button"> Paper </a>
+		</div>
+		<div id="bloc3">
+		     <p>
+		      <button class="btn btn-primary" type="button" data-toggle="collapse" data-target="#collapse{{ id }}" aria-expanded="false" aria-controls="collapse{{ id }}">
+				See More
+		      </button>
+		    </p>
+		</div>
+	     </div>
+	  </div>
+	</div>
+	<div class="row">
+		<div id="bloc2">
+          <span class="dates"> December, 2021 </span>
+          <span class="authors"> Pedro L. C. Rodrigues, Thomas Moreau, Gilles Louppe, Alexandre Gramfort </span>
+    		</div>
+	</div>
+    <div class="row">
+		<div id="bloc2">
+	  	<span class="label_first">   Target: 		  </span>
+        <span class="target"> 		posterior 	 </span>
+  	<span class="label">   Neural Network: 		  </span>        <span class="nn"> 		normalizing-flows 	 </span>
+  	<span class="label">   Samples: 		  </span>        <span class="nn"> 		direct 	 </span>
+  	<span class="label">   Sequential: 		  </span>        <span class="seq_am"> 		yes 	 </span>
+    	</div>
+	</div>
+<div class="collapse" id="collapse{{ id }}">
+{% capture x %}
+* [Code](https://github.com/plcrodrigues/HNPE)
 {% endcapture %}{{ x | markdownify }}
 </div>
  <hr/>


### PR DESCRIPTION
Hi, 
I would like to add our paper on hierarchical neural posterior estimation for SBI.
The abstract is here below:
> Inferring the parameters of a stochastic model based on experimental observations is central to the scientific method. A particularly challenging setting is when the model is strongly indeterminate, i.e. when distinct sets of parameters yield identical observations. This arises in many practical situations, such as when inferring the distance and power of a radio source (is the source close and weak or far and strong?) or when estimating the amplifier gain and underlying brain activity of an electrophysiological experiment. In this work, we present hierarchical neural posterior estimation (HNPE), a novel method for cracking such indeterminacy by exploiting additional information conveyed by an auxiliary set of observations sharing global parameters. Our method extends recent developments in simulation-based inference (SBI) based on normalizing flows to Bayesian hierarchical models. We validate quantitatively our proposal on a motivating example amenable to analytical solutions and then apply it to invert a well known non-linear model from computational neuroscience, using both simulated and real EEG data.
